### PR TITLE
Add toonrun_classic versions to classic_maps.txt

### DIFF
--- a/classic_maps.txt
+++ b/classic_maps.txt
@@ -1836,6 +1836,9 @@ the_daikon_warfare3
 toonrun1
 toonrun2
 toonrun3
+toonrun1_classic
+toonrun2_classic
+toonrun3_classic
 uplink
 uplink_extended
 yabma


### PR DESCRIPTION
Toon Run Classic on SCMapDB is intended to be played in Classic Mode.
http://scmapdb.wikidot.com/map:toon-run-classic

I ported the Toon Run map sources circa Sven 3.x to Sven 5.x with classic mode in mind.